### PR TITLE
Allows using autolayout to constraint the height of the header

### DIFF
--- a/Example/Main/Explore/ExploreViewController.swift
+++ b/Example/Main/Explore/ExploreViewController.swift
@@ -23,15 +23,13 @@ class ExploreViewController: BaseSegementSlideViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override var headerHeight: CGFloat? {
-        return view.bounds.height/4
-    }
-    
     override var headerView: UIView? {
         let headerView = UIImageView()
         headerView.isUserInteractionEnabled = true
         headerView.contentMode = .scaleAspectFill
         headerView.image = UIImage(named: "bg_working.png")
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.heightAnchor.constraint(equalToConstant: 200).isActive = true
         return headerView
     }
     

--- a/Example/Main/LanguageCenter/LanguageCenterViewController.swift
+++ b/Example/Main/LanguageCenter/LanguageCenterViewController.swift
@@ -40,14 +40,12 @@ class LanguageCenterViewController: BaseTransparentSlideViewController {
         return .parent
     }
     
-    override var headerHeight: CGFloat {
-        return centerHeaderView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
-    }
-    
     override var headerView: UIView {
         guard let _ = language else {
             let view = UIView()
             view.backgroundColor = .clear
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.heightAnchor.constraint(equalToConstant: 400).isActive = true
             return view
         }
         return centerHeaderView

--- a/Example/Main/Mine/MineViewController.swift
+++ b/Example/Main/Mine/MineViewController.swift
@@ -34,19 +34,13 @@ class MineViewController: BaseTransparentSlideViewController {
         return .child
     }
     
-    override var headerHeight: CGFloat {
-        if #available(iOS 11.0, *) {
-            return view.bounds.height/4+view.safeAreaInsets.top
-        } else {
-            return view.bounds.height/4+topLayoutGuide.length
-        }
-    }
-    
     override var headerView: UIView {
         let headerView = UIImageView()
         headerView.isUserInteractionEnabled = true
         headerView.contentMode = .scaleAspectFill
         headerView.image = UIImage(named: "bg_computer.png")
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.heightAnchor.constraint(equalToConstant: 400).isActive = true
         return headerView
     }
     

--- a/Source/General/SegementSlideViewController+setup.swift
+++ b/Source/General/SegementSlideViewController+setup.swift
@@ -91,7 +91,6 @@ extension SegementSlideViewController {
     }
     
     internal func setupHeader() {
-        innerHeaderHeight = headerHeight?.rounded(.up)
         innerHeaderView = headerView
     }
     
@@ -100,12 +99,6 @@ extension SegementSlideViewController {
     }
     
     internal func layoutSegementSlideScrollView() {
-        let innerHeaderHeight: CGFloat
-        if let _ = innerHeaderView, let height = self.innerHeaderHeight {
-            innerHeaderHeight = height
-        } else {
-            innerHeaderHeight = 0
-        }
         let topLayoutLength: CGFloat
         if edgesForExtendedLayout.contains(.top) {
             topLayoutLength = 0
@@ -126,13 +119,6 @@ extension SegementSlideViewController {
         }
         if segementSlideHeaderView.trailingConstraint == nil {
             segementSlideHeaderView.trailingConstraint = segementSlideHeaderView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        }
-        if segementSlideHeaderView.heightConstraint == nil {
-            segementSlideHeaderView.heightConstraint = segementSlideHeaderView.heightAnchor.constraint(equalToConstant: innerHeaderHeight)
-        } else {
-            if segementSlideHeaderView.heightConstraint?.constant != innerHeaderHeight {
-                segementSlideHeaderView.heightConstraint?.constant = innerHeaderHeight
-            }
         }
         segementSlideHeaderView.config(innerHeaderView, segementSlideContentView: segementSlideContentView)
         
@@ -187,7 +173,11 @@ extension SegementSlideViewController {
         segementSlideContentView.layer.zPosition = -2
         segementSlideSwitcherView.layer.zPosition = -1
         
-        let contentSize = CGSize(width: view.bounds.width, height: topLayoutLength+innerHeaderHeight+switcherHeight+contentViewHeight+1)
+        let innerHeaderHeight = segementSlideHeaderView.frame.height
+        let contentSize = CGSize(
+            width: view.bounds.width,
+            height: topLayoutLength + innerHeaderHeight + switcherHeight + contentViewHeight + 1
+        )
         if segementSlideScrollView.contentSize != contentSize {
             segementSlideScrollView.contentSize = contentSize
         }

--- a/Source/General/SegementSlideViewController+setup.swift
+++ b/Source/General/SegementSlideViewController+setup.swift
@@ -173,6 +173,8 @@ extension SegementSlideViewController {
         segementSlideContentView.layer.zPosition = -2
         segementSlideSwitcherView.layer.zPosition = -1
         
+        segementSlideHeaderView.layoutIfNeeded()
+        
         let innerHeaderHeight = segementSlideHeaderView.frame.height
         let contentSize = CGSize(
             width: view.bounds.width,

--- a/Source/General/SegementSlideViewController.swift
+++ b/Source/General/SegementSlideViewController.swift
@@ -62,18 +62,6 @@ open class SegementSlideViewController: UIViewController {
         return .parent
     }
     
-    /// the value should contains topLayoutGuide's length(safeAreaInsets.top in iOS 11), if the edgesForExtendedLayout in viewController contains `.top`
-    open var headerHeight: CGFloat? {
-        if edgesForExtendedLayout.contains(.top) {
-            #if DEBUG
-            assert(false, "must override this variable")
-            #endif
-            return nil
-        } else {
-            return nil
-        }
-    }
-    
     open var headerView: UIView? {
         if edgesForExtendedLayout.contains(.top) {
             #if DEBUG

--- a/Source/General/SegementSlideViewController.swift
+++ b/Source/General/SegementSlideViewController.swift
@@ -40,7 +40,7 @@ open class SegementSlideViewController: UIViewController {
         return segementSlideContentView
     }
     public var headerStickyHeight: CGFloat {
-        let headerHeight = segementSlideHeaderView.frame.height
+        let headerHeight = segementSlideHeaderView.frame.height.rounded(.up)
         if edgesForExtendedLayout.contains(.top) {
             return headerHeight - topLayoutLength
         } else {

--- a/Source/General/SegementSlideViewController.swift
+++ b/Source/General/SegementSlideViewController.swift
@@ -19,7 +19,6 @@ open class SegementSlideViewController: UIViewController {
     internal var segementSlideHeaderView: SegementSlideHeaderView!
     internal var segementSlideContentView: SegementSlideContentView!
     internal var segementSlideSwitcherView: SegementSlideSwitcherView!
-    internal var innerHeaderHeight: CGFloat?
     internal var innerHeaderView: UIView?
     
     internal var safeAreaTopConstraint: NSLayoutConstraint?
@@ -41,13 +40,11 @@ open class SegementSlideViewController: UIViewController {
         return segementSlideContentView
     }
     public var headerStickyHeight: CGFloat {
-        guard let innerHeaderHeight = innerHeaderHeight else {
-            return 0
-        }
+        let headerHeight = segementSlideHeaderView.frame.height
         if edgesForExtendedLayout.contains(.top) {
-            return innerHeaderHeight-topLayoutLength
+            return headerHeight - topLayoutLength
         } else {
-            return innerHeaderHeight
+            return headerHeight
         }
     }
     public var contentViewHeight: CGFloat {

--- a/Source/General/TransparentSlideViewController.swift
+++ b/Source/General/TransparentSlideViewController.swift
@@ -72,6 +72,7 @@ open class TransparentSlideViewController: SegementSlideViewController {
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         layoutTitleLabel()
+        reloadNavigationBarStyle()
     }
     
     open override func viewDidLoad() {

--- a/Source/General/TransparentSlideViewController.swift
+++ b/Source/General/TransparentSlideViewController.swift
@@ -35,13 +35,6 @@ open class TransparentSlideViewController: SegementSlideViewController {
     public var storedNavigationBarShadowImage: UIImage? = nil
     public var storedNavigationBarBackgroundImage: UIImage? = nil
     
-    open override var headerHeight: CGFloat {
-        #if DEBUG
-        assert(false, "must override this variable")
-        #endif
-        return 0
-    }
-    
     open override var headerView: UIView {
         #if DEBUG
         assert(false, "must override this variable")

--- a/Source/General/TransparentSlideViewController.swift
+++ b/Source/General/TransparentSlideViewController.swift
@@ -65,7 +65,6 @@ open class TransparentSlideViewController: SegementSlideViewController {
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         layoutTitleLabel()
-        reloadNavigationBarStyle()
     }
     
     open override func viewDidLoad() {


### PR DESCRIPTION
It's better to leverage the power of Autolayout to calculate the height of the header view instead of using a fixed number. 
With Autolayout you can change the height of the header view base on your need without reloading the entire view.