### PR TITLE
fix the childKeyValueObservation was removed

### DIFF
--- a/Source/Content/SegementSlideContentView.swift
+++ b/Source/Content/SegementSlideContentView.swift
@@ -209,7 +209,6 @@ extension SegementSlideContentView {
                 childViewController.endAppearanceTransition()
             }
         }
-        guard index != selectedIndex else { return }
         selectedIndex = index
         delegate?.segementSlideContentView(self, didSelectAtIndex: index, animated: animated)
     }

--- a/Source/General/SegementSlideViewController+setup.swift
+++ b/Source/General/SegementSlideViewController+setup.swift
@@ -191,6 +191,7 @@ extension SegementSlideViewController {
         if segementSlideScrollView.contentSize != contentSize {
             segementSlideScrollView.contentSize = contentSize
         }
+        segementSlideContentView.layoutSubviews()
     }
     
     internal func resetChildViewControllerContentOffsetY() {


### PR DESCRIPTION
in other `SegementSlideViewController`’s `reloadData()` method, the `childKeyValueObservation` was invalidate by the NSNotification of `willClearAllReusableViewControllers`, fix it by reLayoutSubviews() and remove the condition of `index != selectedIndex` in creating the childKeyValueObservation(before create, it will be invalidate, so it doesn't matter)

see: https://github.com/Jiar/SegementSlide/issues/22