### PR TITLE
fix TransparentSlideViewController's reloadNavigationBarStyle

### DIFF
--- a/Source/General/TransparentSlideViewController.swift
+++ b/Source/General/TransparentSlideViewController.swift
@@ -115,7 +115,8 @@ open class TransparentSlideViewController: SegementSlideViewController {
     
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        recoverStoredNavigationBarStyle()
+        hasViewWillAppeared = false
+        recoverStoredNavigationBarStyle()        
     }
     
     open override func scrollViewDidScroll(_ scrollView: UIScrollView, isParent: Bool) {


### PR DESCRIPTION
sometime we need to call `reloadHeader()` to reload the height of headerView because of the info change. in this case, the `TransparentSlideViewController` will call `reloadNavigationBarStyle` to reload, and this will impact the navigationBar's style.

look at this demo(个人信息页的导航栏变化了):

![Kapture 2019-07-11 at 15 43 25](https://user-images.githubusercontent.com/4870617/61031980-22ef4f80-a3f3-11e9-8b30-b4f08cb27400.gif)

add `hasViewWillAppeared = false` in `TransparentSlideViewController`'s `viewWillDisappear` can fix this issue
