### PR TITLE
Add a function to scroll to top when the header view is sticked.

### DIFF
--- a/Source/General/SegementSlideViewController+setup.swift
+++ b/Source/General/SegementSlideViewController+setup.swift
@@ -214,6 +214,19 @@ extension SegementSlideViewController {
             childScrollView.forceFixedContentOffsetY = 0
         }
     }
+  
+  internal func resetCurrentParentViewControllerContentOffsetY(_ parentScrollView: UIScrollView) {
+    defer {
+      scrollViewDidScroll(parentScrollView, isParent: true)
+    }
+    parentKeyValueObservation?.invalidate()
+    resetCurrentChildViewControllerContentOffsetY()
+    resetOtherCachedChildViewControllerContentOffsetY()
+    scrollView.contentOffset.y = 0
+    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+      self.observeScrollViewContentOffset()
+    }
+  }
     
     internal func cleanUpChildKeyValueObservations() {
         let observations = childKeyValueObservations

--- a/Source/General/SegementSlideViewController+setup.swift
+++ b/Source/General/SegementSlideViewController+setup.swift
@@ -223,7 +223,7 @@ extension SegementSlideViewController {
     resetCurrentChildViewControllerContentOffsetY()
     resetOtherCachedChildViewControllerContentOffsetY()
     scrollView.contentOffset.y = 0
-    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       self.observeScrollViewContentOffset()
     }
   }


### PR DESCRIPTION
To fix the issue in #67, a function was added.

The reason why changes to `scrollView.contentOffset` are ignored when the `headerView` is in the sticked state is related to the `scrollView.observe()` method.

As soon as `scrollView.contentOffset` is changed, the `parentScrollViewDidScroll(_:)` is called immediately, and `parentContentOffsetY` is compared with `headerStickyHeight`.

And because `parentScrollView.contentOffset.y` is reset based on the comparison result in the switch statement, the 'scroll to top' operation desired by the user is not executed.

In order to bypass `parentScrollViewDidScroll(_:)` with minimal impact on other parts, I added a function that disables `parentKeyValueObservation` for 2 seconds. If the deactivation time is too short, `contentOffset.y` is intercepted by the `observe()` method before moving to the top, so I set it to 2 seconds.

`contentOffset.y` is reset to zero for 2 seconds when `parentKeyValueObservation` is disabled.

Like `resetCurrentChildViewControllerContentOffsetY` or `resetOtherCachedChildViewControllerContentOffsetY`, the `parentViewController` needs a method to scroll to the top.


If you call `self.resetCurrentParentViewControllerContentOffsetY(scrollView)` in SegementSlideViewController, the `scrollView` is scrolled to the top of the `scrollView` even if `headerView` is sticked.

Thank you.